### PR TITLE
Use a proper sqlstate with non-setof function errors

### DIFF
--- a/src/plproxy.h
+++ b/src/plproxy.h
@@ -435,9 +435,10 @@ typedef struct ProxyFunction
 /* main.c */
 Datum		plproxy_call_handler(PG_FUNCTION_ARGS);
 Datum		plproxy_validator(PG_FUNCTION_ARGS);
-void		plproxy_error(ProxyFunction *func, const char *fmt, ...)
-	__attribute__((format(PG_PRINTF_ATTRIBUTE, 2, 3)));
+void		plproxy_error_with_state(ProxyFunction *func, int sqlstate, const char *fmt, ...)
+	__attribute__((format(PG_PRINTF_ATTRIBUTE, 3, 4)));
 void		plproxy_remote_error(ProxyFunction *func, ProxyConnection *conn, const PGresult *res, bool iserr);
+#define plproxy_error(func,...) plproxy_error_with_state((func), ERRCODE_INTERNAL_ERROR, __VA_ARGS__)
 
 /* function.c */
 void		plproxy_function_cache_init(void);

--- a/test/expected/plproxy_errors.out
+++ b/test/expected/plproxy_errors.out
@@ -125,3 +125,53 @@ ERROR:  function test_runonall_err(unknown) does not exist
 LINE 1: select * from test_runonall_err('dat');
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- make sure that errors from non-setof functions returning <> 1 row have
+-- a proper sqlstate
+create function test_no_results_plproxy()
+returns int
+as $$
+    cluster 'testcluster';
+    run on any;
+    select 1 from pg_database where datname = '';
+$$ language plproxy;
+create function test_no_results()
+returns void
+as $$
+begin
+    begin
+        perform test_no_results_plproxy();
+    exception when no_data_found then
+        null;
+    end;
+end;
+$$ language plpgsql;
+select * from test_no_results();
+ test_no_results 
+-----------------
+ 
+(1 row)
+
+create function test_multi_results_plproxy()
+returns int
+as $$
+    cluster 'testcluster';
+    run on any;
+    select 1 from pg_database;
+$$ language plproxy;
+create function test_multi_results()
+returns void
+as $$
+begin
+    begin
+        perform test_multi_results_plproxy();
+    exception when too_many_rows then
+        null;
+    end;
+end;
+$$ language plpgsql;
+select * from test_multi_results();
+ test_multi_results 
+--------------------
+ 
+(1 row)
+

--- a/test/sql/plproxy_errors.sql
+++ b/test/sql/plproxy_errors.sql
@@ -93,3 +93,45 @@ as $$
     run on all;
 $$ language plproxy;
 select * from test_runonall_err('dat');
+
+-- make sure that errors from non-setof functions returning <> 1 row have
+-- a proper sqlstate
+create function test_no_results_plproxy()
+returns int
+as $$
+    cluster 'testcluster';
+    run on any;
+    select 1 from pg_database where datname = '';
+$$ language plproxy;
+create function test_no_results()
+returns void
+as $$
+begin
+    begin
+        perform test_no_results_plproxy();
+    exception when no_data_found then
+        null;
+    end;
+end;
+$$ language plpgsql;
+select * from test_no_results();
+
+create function test_multi_results_plproxy()
+returns int
+as $$
+    cluster 'testcluster';
+    run on any;
+    select 1 from pg_database;
+$$ language plproxy;
+create function test_multi_results()
+returns void
+as $$
+begin
+    begin
+        perform test_multi_results_plproxy();
+    exception when too_many_rows then
+        null;
+    end;
+end;
+$$ language plpgsql;
+select * from test_multi_results();


### PR DESCRIPTION
Refactored plproxy_error function into plproxy_error_with_state which
accepts an sqlstate argument and made plproxy_error a macro that calls
plproxy_error_with_state with ERRCODE_INTERNAL_ERROR.

Signed-off-by: Oskari Saarenmaa <os@ohmu.fi>